### PR TITLE
Encoder and Decoder for dictionary (Map<string, Value>)

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -74,15 +74,19 @@ module Logger =
     let errorfn str = Printf.kprintf (fun s -> use c = consoleColor ConsoleColor.Red in printfn "%s" s) str
 
 let yarn args =
-    ExecProcess
-        (fun info ->
-            { info with
-                FileName = "yarn"
-                Arguments = args
-            }
-        )
-        (TimeSpan.FromMinutes 10.)
-    |> ignore
+    let code =
+        ExecProcess
+            (fun info ->
+                { info with
+                    FileName = "yarn"
+                    Arguments = args
+                }
+            )
+            (TimeSpan.FromMinutes 10.)
+    if code <> 0 then
+        failwithf "Yarn exited with code: %i" code
+    else
+        ()
 
 Target.Create "Clean" (fun _ ->
     !! "src/**/bin"

--- a/src/Thot.Json/Decode.fs
+++ b/src/Thot.Json/Decode.fs
@@ -3,7 +3,6 @@ module Thot.Json.Decode
 open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Import
-open Fable.AST.Fable
 
 module Helpers =
 

--- a/src/Thot.Json/Encode.fs
+++ b/src/Thot.Json/Encode.fs
@@ -1,6 +1,7 @@
 module Thot.Json.Encode
 
 open Fable.Core.JsInterop
+open System.Threading.Tasks
 
 type Replacer = string -> obj -> obj
 
@@ -128,6 +129,21 @@ let array (values : array<Value>) : Value =
 ///
 let list (values : Value list) : Value =
     FFI.encodeList values
+
+///**Description**
+/// Encode a dictionary
+///**Parameters**
+///  * `values` - parameter of type `Map<string, Value>`
+///
+///**Output Type**
+///  * `Value`
+///
+///**Exceptions**
+///
+let dict (values : Map<string, Value>) : Value =
+    values
+    |> Map.toList
+    |> object
 
 ///**Description**
 /// Convert a `Value` into a prettified string.

--- a/src/Thot.Json/Encode.fs
+++ b/src/Thot.Json/Encode.fs
@@ -1,7 +1,6 @@
 module Thot.Json.Encode
 
 open Fable.Core.JsInterop
-open System.Threading.Tasks
 
 type Replacer = string -> obj -> obj
 

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -331,11 +331,51 @@ Expecting an array but instead got: 1
 
             Assert.AreEqual(expected, actual)
 
+        it "keyValuePairs works" <| fun _ ->
+            let expected = Ok([("a", 1) ; ("b", 2) ; ("c", 3)])
+
+            let actual =
+                decodeString (keyValuePairs int) """{ "a": 1, "b": 2, "c": 3 }"""
+
+            Assert.AreEqual(expected, actual)
+
         it "dict works" <| fun _ ->
             let expected = Ok(Map.ofList([("a", 1) ; ("b", 2) ; ("c", 3)]))
 
             let actual =
                 decodeString (dict int) """{ "a": 1, "b": 2, "c": 3 }"""
+
+            Assert.AreEqual(expected, actual)
+
+        it "dict with custom decoder works" <| fun _ ->
+            let expected = Ok(Map.ofList([("a", Record2.Create 1. 1.) ; ("b", Record2.Create 2. 2.) ; ("c", Record2.Create 3. 3.)]))
+
+            let decodePoint =
+                map2 Record2.Create
+                    (field "a" float)
+                    (field "b" float)
+
+            let actual =
+                decodeString (dict decodePoint)
+                    """
+{
+    "a":
+        {
+            "a": 1,
+            "b": 1
+        },
+    "b":
+        {
+            "a": 2,
+            "b": 2
+        },
+    "c":
+        {
+            "a": 3,
+            "b": 3
+        }
+}
+                    """
 
             Assert.AreEqual(expected, actual)
 

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -331,6 +331,22 @@ Expecting an array but instead got: 1
 
             Assert.AreEqual(expected, actual)
 
+        it "dict works" <| fun _ ->
+            let expected = Ok(Map.ofList([("a", 1) ; ("b", 2) ; ("c", 3)]))
+
+            let actual =
+                decodeString (dict int) """{ "a": 1, "b": 2, "c": 3 }"""
+
+            Assert.AreEqual(expected, actual)
+
+        it "an invalid dict output an error" <| fun _ ->
+            let expected = Error("Expecting an object but instead got: 1")
+
+            let actual =
+                decodeString (dict int) "1"
+
+            Assert.AreEqual(expected, actual)
+
     describe "Inconsistent structure" <| fun _ ->
 
         it "oneOf works" <| fun _ ->

--- a/tests/Tests.Json.Encode.fs
+++ b/tests/Tests.Json.Encode.fs
@@ -77,6 +77,19 @@ describe "Encode" <| fun _ ->
                 ] |> encode 0
         Assert.AreEqual(expected, actual)
 
+    it "a dict works" <| fun _ ->
+        let expected =
+            """{"a":1,"b":2,"c":3}"""
+        let actual =
+            Map.ofList
+                [ ("a", int 1)
+                  ("b", int 2)
+                  ("c", int 3)
+                ]
+            |> dict
+            |> encode 0
+        Assert.AreEqual(expected, actual)
+
     it "using pretty space works" <| fun _ ->
         let expected = "{\n    \"firstname\": \"maxime\",\n    \"age\": 25\n}"
 


### PR DESCRIPTION
Should the name really be `dict`? `map` is excluded naturally.
We followed the Elm example of always having keys of type string.

Fixes #3 