### PR TITLE
Expand valid int range

### DIFF
--- a/src/Thot.Json/Decode.fs
+++ b/src/Thot.Json/Decode.fs
@@ -24,7 +24,7 @@ module Helpers =
     [<Emit("Number.isNaN($0)")>]
     let isNaN (_: obj) : bool = jsNative
 
-    [<Emit("-2147483648 < $0 && $0 < 2147483647 && ($0 | 0) === $0")>]
+    [<Emit("-9007199254740991 < $0 && $0 < 9007199254740991 && ($0 | 0) === $0")>]
     let isValidIntRange (_: obj) : bool = jsNative
 
     [<Emit("isFinite($0) && !($0 % 1)")>]

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -205,10 +205,16 @@ let tests : Test =
                 equal expected actual
 
             testCase "an invalid int [invalid range: too small] output an error" <| fun _ ->
+                #if FABLE_COMPILER
+                let expected = Error("Expecting an int but instead got: -9007199254740992\nReason: Value was either too large or too small for an int")
+                let actual =
+                    decodeString int "-9007199254740992"
+                #else            
                 let expected = Error("Expecting an int but instead got: -2147483649\nReason: Value was either too large or too small for an int")
                 let actual =
                     decodeString int "-2147483649"
-
+                #endif
+                
                 equal expected actual
         ]
 

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -198,9 +198,15 @@ let tests : Test =
                 equal expected actual
 
             testCase "an invalid int [invalid range: too big] output an error" <| fun _ ->
+                #if FABLE_COMPILER
+                let expected = Error("Expecting an int but instead got: 9007199254740992\nReason: Value was either too large or too small for an int")
+                let actual =
+                    decodeString int "9007199254740992"
+                #else
                 let expected = Error("Expecting an int but instead got: 2147483648\nReason: Value was either too large or too small for an int")
                 let actual =
                     decodeString int "2147483648"
+                #endif
 
                 equal expected actual
 


### PR DESCRIPTION
The minimum safe int in JS is:

```js
Number.MIN_SAFE_INTEGER // -9007199254740991
```

The maximum is:

```js
Number.MAX_SAFE_INTEGER // 9007199254740991
```

Expand the valid range check in JS to cover the range.